### PR TITLE
Update database.php

### DIFF
--- a/Site/lib/cms/joomla_common/base/database.php
+++ b/Site/lib/cms/joomla_common/base/database.php
@@ -228,7 +228,7 @@ class SPJoomlaDb
 				foreach ( $o as $p ) {
 					if ( strstr( $p, '.' ) ) {
 						$p = explode( '.', $p );
-						$order[ ] = $p[ 0 ] . ' ' . strtoupper( $p[ 1 ] );
+						$order[ ] = $p[ 0 ] . '.' . strtoupper( $p[ 1 ] );
 					}
 					else {
 						$order[ ] = $p;


### PR DESCRIPTION
The block 
	$p = explode( '.', $p );
	$order[ ] = $p[ 0 ] . '.' . strtoupper( $p[ 1 ] );

$p contains table name . After exploding  dot is missing . which is required if multiple tables are involved.
$p[0] = represent table name 
$p[1]= Column name;
if there is no dot Column may become ambiguous . and  it will leads to mysql error

Thanks
Kishore