### PR TITLE
Update loader.php in order to pass phar include

### DIFF
--- a/Site/lib/base/fs/loader.php
+++ b/Site/lib/base/fs/loader.php
@@ -23,8 +23,10 @@ use Sobi\Autoloader\Autoloader;
 use Sobi\Framework;
 
 if ( !( class_exists( '\\Sobi\\Framework' ) ) ) {
-	// Suppressing warning because the error is being handled
-	@include_once 'phar://' . SOBI_ROOT . '/libraries/sobi/Sobi-1.0.2.phar.tar.gz/Framework.php';
+	if (!file_exists( SOBI_ROOT . '/libraries/sobi/Framework.php' )) {
+		// Suppressing warning because the error is being handled
+		@include_once 'phar://' . SOBI_ROOT . '/libraries/sobi/Sobi-1.0.2.phar.tar.gz/Framework.php';				
+	}
 	if ( !( class_exists( '\\Sobi\\Framework' ) ) ) {
 		if ( file_exists( SOBI_ROOT . '/libraries/sobi/Framework.php' ) ) {
 			include_once SOBI_ROOT . '/libraries/sobi/Framework.php';


### PR DESCRIPTION
In some servers the phar include fails silently producing a blank page and without any error log. This pull request tries to resolve this problem by jump over the include line when the uncompressed Framework.php file exists.