### PR TITLE
Sort selectlists case insensitive

### DIFF
--- a/Site/opt/fields/inbox.php
+++ b/Site/opt/fields/inbox.php
@@ -341,7 +341,7 @@ class SPField_Inbox extends SPFieldType implements SPFieldInterface
 		}
 		if ( function_exists( 'iconv' ) ) {
 			uasort( $fdata, function ( $a, $b ) {
-				return strcmp( iconv( 'UTF-8', 'ASCII//TRANSLIT', $a ), iconv( 'UTF-8', 'ASCII//TRANSLIT', $b ) );
+				return strcmp( iconv( 'UTF-8', 'ASCII//TRANSLIT', strtolower($a) ), iconv( 'UTF-8', 'ASCII//TRANSLIT', strtolower($b) ) );
 			} );
 		}
 		else {


### PR DESCRIPTION
Currently the sorting prepends lowercase values to the end of the select list which imho is wrong.

Input: 
```
Tim
bob
apple
```
Expected:
```
apple
bob
Tim
```

But instead currently it sorts it like this:

```
Tim
apple
bob
```